### PR TITLE
:sparkles: add terraform for the kubernetes cluster (TEK-20)

### DIFF
--- a/Jenkins/JenkinsDeployment-guide.md
+++ b/Jenkins/JenkinsDeployment-guide.md
@@ -11,7 +11,7 @@ Before you start, make sure you have the following:
 3. **Terraform Installed**: Install Terraform on your local machine. Refer to the [Terraform installation guide](https://www.terraform.io/downloads).
 4. **Google Cloud SDK**: Install Google Cloud SDK on your local machine. Follow the instructions [here](https://cloud.google.com/sdk/docs/install).
 5. **Service Account Key**: Create a service account in GCP with Editor access, and download its JSON key. (See instructions below)
-6. **Activate APIs**: Enable the Compute Engine and Cloud Storage APIs in your GCP project.
+6. **Activate APIs**: Enable the Compute Engine, Kubernetes Engine API  and Cloud Storage APIs in your GCP project.
 7. **Set the variables in the terraform configuration** (see below)
 8. **Ansible Installed**: Install Ansible on your local machine. Refer to the [Ansible installation guide](https://docs.ansible.com/ansible/latest/installation_guide/index.html).
 
@@ -61,7 +61,7 @@ The script will:
 - And finally, display the **initial admin password** to access Jenkins
 
 ```sh
-run-jenkins-install.sh
+ ~ Whanos/Jenkins$> run-jenkins-install.sh
 ```
 
 ## Step-by-Step Instructions (manual detailed instructions)
@@ -107,7 +107,7 @@ run-jenkins-install.sh
 1. **Initialize Terraform**:
 
    ```sh
-   terraform init
+ ~ Whanos/Jenkins/terraform$> terraform init
    ```
 
    This command downloads the necessary provider plugins.
@@ -123,7 +123,7 @@ run-jenkins-install.sh
 3. **Apply the Configuration**:
 
    ```sh
-   terraform apply
+ ~ Whanos/Jenkins/terraform$> terraform apply
    ```
 
    Type `yes` when prompted to confirm the creation of resources.
@@ -149,3 +149,11 @@ _type `yes` if prompted to accept the ssh key fingerprint_
   sudo cat /var/lib/jenkins/secrets/initialAdminPassword
   ```
 - Follow the Jenkins setup wizard to complete the installation.
+
+## Reset all the deployment resources on google cloud platform
+
+To delete all the resources created by Terraform, run the following command:
+
+```sh
+ ~ Whanos/Jenkins/terraform$> terraform destroy
+```

--- a/Jenkins/terraform/main.tf
+++ b/Jenkins/terraform/main.tf
@@ -1,3 +1,5 @@
+## VPS Instance
+
 provider "google" {
   credentials = file(var.service_account_key_path)
   project     = var.project_id
@@ -53,4 +55,31 @@ resource "google_compute_firewall" "default" {
 
   target_tags   = ["http-server", "https-server"]
   source_ranges = ["0.0.0.0/0"]
+}
+
+## Kubernetes Cluster
+
+resource "google_container_cluster" "kubernetes_cluster" {
+  name     = "kubernetes-cluster"
+  location = "europe-west1"
+  deletion_protection = false
+
+  node_config {
+    machine_type = "g1-small" # 1 vCPU, 0.6 GB memory
+    disk_size_gb = 10
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+
+  initial_node_count = 1
+}
+
+output "kubernetes_cluster_endpoint" {
+  value = google_container_cluster.kubernetes_cluster.endpoint
+}
+
+output "kubernetes_cluster_ca_certificate" {
+  value = base64decode(google_container_cluster.kubernetes_cluster.master_auth.0.cluster_ca_certificate)
 }


### PR DESCRIPTION
This pull request includes updates to the Jenkins deployment guide and Terraform configuration to support Kubernetes clusters. The most important changes include renaming the guide file, updating the list of required APIs, and adding Kubernetes cluster resources to the Terraform configuration.

Documentation updates:
* [`Jenkins/JenkinsDeployment-guide.md`](diffhunk://#diff-322057cf5aedfda359cb666b4c90b935d6a80fe64fcd9cd49fcbd9dcb168c278L14-R14): Renamed from `Jenkins/terraform-guide.md`, added Kubernetes Engine API to the list of required APIs, and updated command prompts for better clarity. [[1]](diffhunk://#diff-322057cf5aedfda359cb666b4c90b935d6a80fe64fcd9cd49fcbd9dcb168c278L14-R14) [[2]](diffhunk://#diff-322057cf5aedfda359cb666b4c90b935d6a80fe64fcd9cd49fcbd9dcb168c278L64-R64) [[3]](diffhunk://#diff-322057cf5aedfda359cb666b4c90b935d6a80fe64fcd9cd49fcbd9dcb168c278L110-R110) [[4]](diffhunk://#diff-322057cf5aedfda359cb666b4c90b935d6a80fe64fcd9cd49fcbd9dcb168c278L126-R126) [[5]](diffhunk://#diff-322057cf5aedfda359cb666b4c90b935d6a80fe64fcd9cd49fcbd9dcb168c278R152-R159)

Terraform configuration updates:
* [`Jenkins/terraform/main.tf`](diffhunk://#diff-f549454b479f2a1c2ea3e19b136027e16e97e972b1a58c5c07031024b7894338R1-R2): Added configuration for creating a Kubernetes cluster, including resource definition and output variables for the cluster endpoint and CA certificate. [[1]](diffhunk://#diff-f549454b479f2a1c2ea3e19b136027e16e97e972b1a58c5c07031024b7894338R1-R2) [[2]](diffhunk://#diff-f549454b479f2a1c2ea3e19b136027e16e97e972b1a58c5c07031024b7894338R59-R85)